### PR TITLE
pkg: add type lints.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,16 @@ jobs:
         node-version: 20.x
 
     - name: Install tools
-      run: npm install --location=global bslint
+      run: npm install --location=global bslint typescript
 
     - name: Install dependencies
       run: npm install
 
     - name: Lint
       run: npm run lint
+
+    - name: Lint types
+      run: npm run lint-types
 
   test:
     name: Test

--- a/lib/list.js
+++ b/lib/list.js
@@ -11,14 +11,15 @@ const assert = require('bsert');
 /**
  * Double Linked List
  * @alias module:utils.List
+ * @template T
  */
 
 class List {
   /**
    * Create a list.
    * @constructor
-   * @property {ListItem|null} head
-   * @property {ListItem|null} tail
+   * @property {ListItem<T>|null} head
+   * @property {ListItem<T>|null} tail
    * @property {Number} size
    */
 
@@ -50,7 +51,7 @@ class List {
 
   /**
    * Remove the first item in the list.
-   * @returns {ListItem}
+   * @returns {ListItem<T>}
    */
 
   shift() {
@@ -66,7 +67,7 @@ class List {
 
   /**
    * Prepend an item to the linked list (sets new head).
-   * @param {ListItem}
+   * @param {ListItem<T>} item
    * @returns {Boolean}
    */
 
@@ -76,7 +77,7 @@ class List {
 
   /**
    * Append an item to the linked list (sets new tail).
-   * @param {ListItem}
+   * @param {ListItem} item
    * @returns {Boolean}
    */
 
@@ -86,7 +87,7 @@ class List {
 
   /**
    * Remove the last item in the list.
-   * @returns {ListItem}
+   * @returns {ListItem<T>}
    */
 
   pop() {
@@ -103,8 +104,8 @@ class List {
   /**
    * Insert item into the linked list.
    * @private
-   * @param {ListItem|null} ref
-   * @param {ListItem} item
+   * @param {ListItem<T>|null} ref
+   * @param {ListItem<T>} item
    * @returns {Boolean}
    */
 
@@ -146,7 +147,7 @@ class List {
   /**
    * Remove item from the linked list.
    * @private
-   * @param {ListItem}
+   * @param {ListItem<T>} item
    * @returns {Boolean}
    */
 
@@ -209,8 +210,8 @@ class List {
   /**
    * Slice the list to an array of items.
    * Will remove the items sliced.
-   * @param {Number?} total
-   * @returns {ListItem[]}
+   * @param {Number} [total=-1]
+   * @returns {ListItem<T>[]}
    */
 
   slice(total) {
@@ -247,7 +248,7 @@ class List {
 
   /**
    * Convert the list to an array of items.
-   * @returns {ListItem[]}
+   * @returns {ListItem<T>[]}
    */
 
   toArray() {
@@ -263,6 +264,7 @@ class List {
 /**
  * List Item
  * @alias module:utils.ListItem
+ * @template T
  */
 
 class ListItem {
@@ -270,8 +272,7 @@ class ListItem {
    * Create a list item.
    * @constructor
    * @private
-   * @param {String} key
-   * @param {Object} value
+   * @param {T} value
    */
 
   constructor(value) {
@@ -285,9 +286,8 @@ class ListItem {
  * Expose
  */
 
-exports = List;
-exports.List = List;
-exports.ListItem = ListItem;
-exports.Item = ListItem;
+List.List = List;
+List.ListItem = ListItem;
+List.Item = ListItem;
 
-module.exports = exports;
+module.exports = List;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "bsert": "~0.0.12"
       },
       "devDependencies": {
-        "bmocha": "^2.1.8"
+        "bmocha": "^2.1.8",
+        "bts-type-deps": "^0.0.3"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -38,6 +39,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/bts-type-deps": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/bts-type-deps/-/bts-type-deps-0.0.3.tgz",
+      "integrity": "sha512-OQHGWhX5amae6Vj6ShlGaQu0sNCICgJ5YspNZPRzfR5RobrD+wjm5vkZK/J3EH5b/ymxqSWo9VkiFNpCxjaG2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,13 +15,15 @@
   "main": "./lib/blst.js",
   "scripts": {
     "lint": "eslint lib/ test/",
+    "lint-types": "tsc -p .",
     "test": "bmocha --reporter spec test/*-test.js"
   },
   "dependencies": {
     "bsert": "~0.0.12"
   },
   "devDependencies": {
-    "bmocha": "^2.1.8"
+    "bmocha": "^2.1.8",
+    "bts-type-deps": "^0.0.3"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "include": [
+    "lib/**/*.js"
+  ],
+  "compilerOptions": {
+    "rootDir": ".",
+    "target": "ES2020",
+    "lib": [
+      "ES2020"
+    ],
+
+    "noEmit": true,
+
+    "allowJs": true,
+    "checkJs": true,
+    "maxNodeModuleJsDepth": 10,
+
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+
+    "stripInternal": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+
+    "typeRoots": [
+      "node_modules/bts-type-deps/types"
+    ]
+  }
+}


### PR DESCRIPTION
Add jsdoc + typescript type lint support.

- This version enforces all items in the list to be the same type. This is the use case in hsd/bcoin.